### PR TITLE
Fixed duplicate entries in autocomplete results

### DIFF
--- a/routes/villagers.js
+++ b/routes/villagers.js
@@ -423,7 +423,8 @@ router.get('/autocomplete', function (req, res, next) {
                     prefix: req.query.q,
                     completion: {
                         field: 'suggest',
-                        size: 5
+                        size: 5,
+                        skip_duplicates: true
                     }
                 }
             }


### PR DESCRIPTION
Added ES tag `skip_duplicates: true` to prevent duplicate autocomplete results.