### PR TITLE
Better Autocomplete and Search

### DIFF
--- a/bin/util
+++ b/bin/util
@@ -32,7 +32,25 @@ async function deleteSearchIndex() {
 async function buildSearchIndex() {
     // Create the index.
     await es.indices.create({
-        index: searchConfig.elasticSearchIndexName
+        index: searchConfig.elasticSearchIndexName,
+        body: {
+            settings: {
+                analysis: {
+                    analyzer: {
+                        vdb_asciifolding: {
+                            tokenizer: 'standard',
+                            filter: ['with_orig_asciifolding', 'lowercase']
+                        }
+                    },
+                    filter: {
+                        with_orig_asciifolding: {
+                            type: 'asciifolding',
+                            preserve_original: true
+                        }
+                    }
+                }
+            }
+        }
     });
 
     // Define the index mappings properly.
@@ -41,7 +59,8 @@ async function buildSearchIndex() {
         body: {
             properties: {
                 suggest: {
-                    type: 'completion'
+                    type: 'completion',
+                    analyzer: 'vdb_asciifolding'
                 },
                 type: {
                     type: 'keyword'
@@ -83,7 +102,8 @@ async function buildSearchIndex() {
                     type: 'keyword'
                 },
                 name: {
-                    type: 'text'
+                    type: 'text',
+                    analyzer: 'vdb_asciifolding'
                 }
             }
         }

--- a/data/villagers/etoile.json
+++ b/data/villagers/etoile.json
@@ -24,6 +24,6 @@
       }
     }
   },
-  "name": "Etoile",
+  "name": "Étoile",
   "id": "etoile"
 }

--- a/data/villagers/renee.json
+++ b/data/villagers/renee.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "name": "Renée",
+  "name": "Renée",
   "id": "renee"
 }

--- a/public/stylesheets/autocomplete.less
+++ b/public/stylesheets/autocomplete.less
@@ -1,0 +1,29 @@
+#autocomplete {
+    position: relative;
+}
+
+#autocomplete-items {
+    position: absolute;
+    border: 1px solid #d4d4d4;
+    border-bottom: none;
+    border-top: none;
+    z-index: 99;
+    top: 100%;
+    left: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+
+    li {
+        padding: 10px;
+        cursor: pointer;
+        background-color: #fff;
+        border-bottom: 1px solid rgb(206, 212, 218);
+        font-weight: bold;
+    }
+
+    li:hover {
+        background-color: #eee;
+    }
+}

--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -15,6 +15,9 @@
   background: #fff;
 }
 
+// Autocomplete
+@import 'autocomplete.less';
+
 // Entity browser
 @import 'browser.less';
 

--- a/routes/autocomplete.js
+++ b/routes/autocomplete.js
@@ -19,7 +19,7 @@ router.get('/', function (req, res, next) {
                     prefix: req.query.q,
                     completion: {
                         field: 'suggest',
-                        size: 10,
+                        size: 5,
                         skip_duplicates: true
                     }
                 }

--- a/src/search/autocomplete.js
+++ b/src/search/autocomplete.js
@@ -2,11 +2,22 @@ import $ from "jquery";
 import _ from 'underscore';
 
 $(document).ready(() => {
+    /**
+     * Make the list invisible.
+     */
+    const hideList = () => {
+        $('#autocomplete-items').hide();
+    };
+
+    /**
+     * Get the list from the server.
+     * @param e
+     */
     const fillAutoComplete = (e) => {
-        let dataList = $('#qautocomplete');
-        let q = $(e.target).val().trim();
+        const dataList = $('#autocomplete-items');
+        dataList.empty();
+        const q = $(e.target).val().trim();
         if (q.length === 0) {
-            dataList.empty();
             return;
         }
 
@@ -15,13 +26,32 @@ $(document).ready(() => {
             type: 'GET',
             dataType: 'json',
             success: (suggestions) => {
-                dataList.empty();
+                dataList.show();
                 for (let s of suggestions) {
-                    dataList.append($('<option></option>').attr('value', s));
+                    const elem = $('<li></li>')
+                        .text(s)
+                        .on('click', doAutoComplete);
+                    dataList.append(elem);
                 }
             }
         });
     };
 
+    /**
+     * Fill in the box and submit the form.
+     * @param e
+     */
+    const doAutoComplete = (e) => {
+        if (e.target) {
+            $('#q').val($(e.target).text());
+            $('#search-form').submit();
+        }
+    };
+
+    // On typing or focus in, show auto complete list.
     $('#q').on('input', _.debounce(fillAutoComplete, 100));
+    $('#q').on('focusin', _.debounce(fillAutoComplete, 100));
+
+    // On lost focus, destroy the list.
+    $('body').on('click', hideList);
 });

--- a/src/search/autocomplete.js
+++ b/src/search/autocomplete.js
@@ -17,10 +17,7 @@ $(document).ready(() => {
             success: (suggestions) => {
                 dataList.empty();
                 for (let s of suggestions) {
-                    // If they typed an exact name, they know what they want, so don't show it anymore.
-                    if (s.toLowerCase() !== q.toLowerCase()) {
-                        dataList.append($('<option></option>').attr('value', s));
-                    }
+                    dataList.append($('<option></option>').attr('value', s));
                 }
             }
         });

--- a/views/partials/search-bar.hbs
+++ b/views/partials/search-bar.hbs
@@ -1,10 +1,11 @@
 <div id="search-bar" class="bg-dark">
-    <form class="form" method="get" action="/search">
-        <div class="input-group">
+    <form class="form" method="get" action="/search" id="search-form">
+        <div class="input-group" id="autocomplete">
             <label class="sr-only" for="q">Search for a villager or item</label>
             <input type="text" class="form-control" maxlength="64" id="q" name="q"
                    placeholder="Item or villager name" autoComplete="off" list="qautocomplete"
                    value="{{searchQuery}}"/>
+            <ul id="autocomplete-items" style="display: none;"></ul>
             <span class="input-group-btn">
                 <button class="btn btn-primary" type="submit"><span class="fas fa-search"></span></button>
             </span>


### PR DESCRIPTION
This pull request does three things:

1) Changes the Elastic Search indexes to collapse ASCII characters like é into e, so that when someone searches for Renee or Etoile, they can still find Renée and Étoile. 
2) Addresses problems I saw with autocomplete in analytics. I would see people search for things like Chief and mistakenly make requests like ChChief. This actually led to some users leaving the site so that's bad and this pull request addresses that by not relying on mediocre browser implementations of autocomplete. Autocomplete behavior change are vast, so please try it out and report your experience;
3) If there is only one search result and you are doing a purely textual query, we automatically redirect to that search result. I am worried this part could have strange edge cases, but I hope not. 