### PR TITLE
Issue #48 Better Title Tags for Error Pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ app.use(function(err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
-
+  res.locals.pageTitle = err.status + " " + err.message;
   // render the error page
   res.status(err.status || 500);
   res.render('error');

--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ app.set('views', path.join(__dirname, 'views'));
 const handlebars = hbs.create({
     extname: 'hbs',
     defaultLayout: 'main',
+    helpers: require(__dirname + '/helpers/handlebars'),
     layoutsDir: __dirname + '/views/layouts/',
     partialsDir: __dirname + '/views/partials/',
 });

--- a/helpers/handlebars.js
+++ b/helpers/handlebars.js
@@ -1,0 +1,12 @@
+module.exports = {
+    /**
+     * Handlebars helper to add commas to a number
+     * Usage {{toLocaleString param}}
+     *
+     * @param number
+     * @returns {string}
+     */
+    toLocaleString: function (number) {
+        return number.toLocaleString()
+    }
+};

--- a/src/search/paginator.js
+++ b/src/search/paginator.js
@@ -64,7 +64,7 @@ export default class Paginator extends React.Component {
         }
         return (
             <div className="text-right">
-                <p>Results {this.props.startIndex} - {this.props.endIndex} of {this.props.totalCount}</p>
+                <p>Results {this.props.startIndex} - {this.props.endIndex} of {this.props.totalCount.toLocaleString()}</p>
                 <nav aria-label="page navigation">
                     <ul className="pagination justify-content-end">
                         {previousPageLink}

--- a/views/item.hbs
+++ b/views/item.hbs
@@ -123,13 +123,13 @@
                         <td class="align-middle">
                             <ul class="list-unstyled">
                                 {{#each bellCost }}
-                                    <li> <span class="fas fa-bell"></span> {{this}} bells</li>
+                                    <li> <span class="fas fa-bell"></span> {{toLocaleString this}} bells</li>
                                 {{/each}}
                                 {{#each meowCost }}
-                                    <li><span class="fas fa-money-bill-wave"></span> {{this}} MEOW coupons</li>
+                                    <li><span class="fas fa-money-bill-wave"></span> {{toLocaleString this}} MEOW coupons</li>
                                 {{/each}}
                                 {{#each milesCost }}
-                                    <li><span class="fas fa-money-bill-wave"></span> {{this}} Nook miles</li>
+                                    <li><span class="fas fa-money-bill-wave"></span> {{toLocaleString this}} Nook miles</li>
                                 {{/each}}
                             </ul>
                         </td>
@@ -143,7 +143,7 @@
                             {{#if sellable }}
                                 <ul class="list-unstyled">
                                     {{#each bellPrice }}
-                                        <li><span class="fas fa-bell"></span> {{this}} bells</li>
+                                        <li><span class="fas fa-bell"></span> {{toLocaleString this}} bells</li>
                                     {{/each}}
                                 </ul>
                             {{else}}


### PR DESCRIPTION
Addresses issue #48 
Adds a page title to error pages such as "404 Item not found | Animal Crossing ...." instead of "| Animal Crossing ...."