### PR TITLE
Ocarina category: Usables->Tools

### DIFF
--- a/data/items/ocarina.json
+++ b/data/items/ocarina.json
@@ -14,5 +14,5 @@
       }
     }
   },
-  "category": "Usables"
+  "category": "Tools"
 }


### PR DESCRIPTION
New Horizons: The Ocarina acts in exactly the same way as the Pan flute (already in the tools category).

I couldn't see any others in the Usables category which needed moving, and in the game, I haven't seen any other musical instruments behave in this way (yet).