### PR TITLE
Fix Rose Crown, Fossil

### DIFF
--- a/data/items/fossil.json
+++ b/data/items/fossil.json
@@ -12,6 +12,16 @@
       "sources": [
         "Dig spot"
       ]
+    },
+    "nh": {
+      "orderable": false,
+      "sellPrice": {
+        "currency": "bells",
+        "value": 100
+      },
+      "sources": [
+        "Dig spot"
+      ]
     }
   }
 }

--- a/data/items/rose-crown.json
+++ b/data/items/rose-crown.json
@@ -10,9 +10,9 @@
         "value": 480
       },
       "recipe": {
-        "red-rose": 2,
-        "yellow-rose": 2,
-        "white-rose": 2
+        "red-roses": 2,
+        "yellow-roses": 2,
+        "white-roses": 2
       },
       "variations": {
         "colorful": "Colorful"


### PR DESCRIPTION
Two bugs in the data set I found this morning:

 - The Rose Crown item is present in ACNH, and depends on `{color}-rose`, which isn't marked present in ACNH. However, `{color}-roses` is marked present, so the Rose Crown should probably depend on that.
 - `fossil-doorplate` is present in ACNH, but depends on `fossil`, which isn't marked present. The 100 bell price was verified by trying to sell two different unidentified fossils. 