### PR TITLE
scroll to top using jquery not anchor because anchor destroys our state

### DIFF
--- a/src/search/browser.js
+++ b/src/search/browser.js
@@ -79,14 +79,16 @@ class Browser extends React.Component {
                                        startIndex={this.state.startIndex}
                                        endIndex={this.state.endIndex}
                                        totalCount={this.state.totalCount}
-                                       totalPages={this.state.totalPages}/>
+                                       totalPages={this.state.totalPages}
+                                       topAnchor="#browser" />
                             <SearchResults results={this.state.results} />
                             <Paginator onPageChange={this.setPage}
                                        currentPage={this.state.currentPage}
                                        startIndex={this.state.startIndex}
                                        endIndex={this.state.endIndex}
                                        totalCount={this.state.totalCount}
-                                       totalPages={this.state.totalPages}/>
+                                       totalPages={this.state.totalPages}
+                                       topAnchor="#browser" />
                         </div>
                     </div>
                 </div>

--- a/src/search/paginator.js
+++ b/src/search/paginator.js
@@ -1,4 +1,5 @@
 import React from "react";
+import $ from 'jquery'
 
 /**
  *
@@ -30,13 +31,13 @@ export default class Paginator extends React.Component {
         if (this.props.currentPage === 1) {
             previousPageLink = (
                 <li className="page-item disabled">
-                    <a className="page-link" href="#browser" tabIndex="-1">Previous page</a>
+                    <a className="page-link" href="#" tabIndex="-1">Previous page</a>
                 </li>
             );
         } else {
             previousPageLink = (
                 <li className="page-item">
-                    <a className="page-link" href="#browser"
+                    <a className="page-link" href="#"
                        onClick={this.previousPage}
                        tabIndex="-1">
                         Previous page
@@ -76,14 +77,28 @@ export default class Paginator extends React.Component {
     }
 
     previousPage(e) {
+        e.preventDefault();
+        this.scrollToTop();
         if (this.props.currentPage > 1) {
             this.props.onPageChange(this.props.currentPage - 1);
         }
     }
 
     nextPage(e) {
+        e.preventDefault();
+        this.scrollToTop();
         if (this.props.currentPage < this.props.totalPages) {
             this.props.onPageChange(this.props.currentPage + 1);
+        }
+    }
+
+    /**
+     * Return user to the top of the browser (not top of page) on page change.
+     */
+    scrollToTop() {
+        const offset = $(this.props.topAnchor).offset();
+        if (offset && offset.top) {
+            $('html, body').scrollTop(offset.top);
         }
     }
 }

--- a/src/search/paginator.js
+++ b/src/search/paginator.js
@@ -1,5 +1,5 @@
 import React from "react";
-import $ from 'jquery'
+import $ from 'jquery';
 
 /**
  *


### PR DESCRIPTION
Closes #212 

This touches the browser so it should be thoroughly tested on all devices and treated with care. 

To understand what this fixes:
* In production, go to a page such as the villager browser. Scroll to bottom, jump a few pages, and then try to use the back button. The back button behavior is radically inconsistent. Then, try it locally after building the JavaScript in this branch. You should find proper back button behavior again. 