### PR TITLE
[WIP] New schema

### DIFF
--- a/bin/validate
+++ b/bin/validate
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs");
+
+const validate = require("jsonschema").validate;
+const itemSchema = require("../data/models/item");
+
+const dataStorePath = path.join("data", "items");
+const files = fs.readdirSync(dataStorePath);
+
+for (let file of files) {
+  const filePath = path.join(dataStorePath, file);
+  console.log("Processing " + filePath);
+  const data = fs.readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(data);
+  const validation = validate(parsed, itemSchema);
+  if (!validation.valid) {
+    throw Error(validation.errors);
+  }
+}

--- a/data/models/item.js
+++ b/data/models/item.js
@@ -30,6 +30,15 @@ module.exports = {
     game: {
       type: "object",
       properties: {
+        name: {
+          type: "object",
+          patternProperties: {
+            // Localization key
+            "^[\\w-]+$": {
+              type: "string",
+            },
+          },
+        },
         orderable: {
           type: "boolean",
         },
@@ -55,9 +64,6 @@ module.exports = {
   type: "object",
   properties: {
     id: {
-      type: "string",
-    },
-    name: {
       type: "string",
     },
     games: {
@@ -116,6 +122,7 @@ module.exports = {
             recipe: {
               type: "object",
               patternProperties: {
+                // Recipe key
                 "^[\\w-]+$": {
                   type: "integer",
                 },
@@ -125,6 +132,7 @@ module.exports = {
             variations: {
               type: "object",
               patternProperties: {
+                // Variation key
                 "^[\\w-]+$": {
                   type: "string",
                 },

--- a/data/models/item.js
+++ b/data/models/item.js
@@ -1,0 +1,152 @@
+module.exports = {
+  definitions: {
+    price: {
+      type: "object",
+      properties: {
+        currency: {
+          type: "string",
+        },
+        value: {
+          type: "integer",
+        },
+      },
+      additionalProperties: false,
+    },
+    buyPrices: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          currency: {
+            type: "string",
+          },
+          value: {
+            type: "integer",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+    game: {
+      type: "object",
+      properties: {
+        orderable: {
+          type: "boolean",
+        },
+        sources: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        sellPrice: {
+          $ref: "#/definitions/price",
+        },
+        buyPrices: {
+          type: "array",
+          items: {
+            $ref: "#/definitions/price",
+          },
+        },
+      },
+    },
+  },
+
+  type: "object",
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    games: {
+      type: "object",
+      properties: {
+        nl: {
+          allOf: [
+            {
+              $ref: "#/definitions/game",
+            },
+          ],
+          properties: {
+            set: {
+              type: "string",
+            },
+            rvs: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            interiorThemes: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            fashionThemes: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            orderable: {},
+            sources: {},
+            sellPrice: {},
+            buyPrices: {},
+          },
+          additionalProperties: false,
+        },
+        ac: {
+          $ref: "#/definitions/game",
+          additionalProperties: false,
+        },
+        "afe+": {
+          $ref: "#/definitions/game",
+          additionalProperties: false,
+        },
+        nh: {
+          allOf: [
+            {
+              $ref: "#/definitions/game",
+            },
+          ],
+          properties: {
+            recipe: {
+              type: "object",
+              patternProperties: {
+                "^[\\w-]+$": {
+                  type: "integer",
+                },
+              },
+              additionalProperties: false,
+            },
+            variations: {
+              type: "object",
+              patternProperties: {
+                "^[\\w-]+$": {
+                  type: "string",
+                },
+              },
+              additionalProperties: false,
+            },
+            customizable: {
+              type: "boolean",
+            },
+            orderable: {},
+            sources: {},
+            sellPrice: {},
+            buyPrices: {},
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    },
+    category: {
+      type: "string",
+    },
+  },
+  additionalProperties: false,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5446,6 +5446,12 @@
         }
       }
     },
+    "jsonschema": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.6.tgz",
+      "integrity": "sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==",
+      "dev": true
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build-js": "webpack --mode production",
     "build-css": "lessc public/stylesheets/style.less public/stylesheets/style.css -x",
     "watch-less": "grunt",
-    "watch-js": "webpack --mode development --watch"
+    "watch-js": "webpack --mode development --watch",
+    "validate-schemas": "node ./bin/validate"
   },
   "dependencies": {
     "@babel/core": "^7.7.2",
@@ -52,7 +53,8 @@
     "grunt-cli": "^1.3.2",
     "grunt-contrib-less": "^2.0.0",
     "grunt-contrib-watch": "^1.1.0",
-    "nodemon": "^2.0.2"
+    "nodemon": "^2.0.2",
+    "jsonschema": "^1.2.6"
   },
   "nodemonConfig": {
     "ignore": [


### PR DESCRIPTION
- [x] Define schema for current version of the data.
- [x] Modify schema for localizations.

This PR adds two changes, first one add json schema for the item data so it can be validated. Validation can be run with `npm run validate-schemas`. Pointing to 66e6f27ebe0fab19b099efcaa26ca82bea12d9ae this should run without errors, but running for last commit will fail as data is not prepared yet for the new schema.