### PR TITLE
Add .gitattributes file to ensure consistent checkout behavior for Bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
As I hinted in #256, currently most Windows users would be required to clone the Git repository with `core.autocrlf` set as `input` or `none`. The reason for this is because the recommended default configuration for Git for Windows is to checkout text files with Windows-style line endings (`"\r\n"`), which differs from Unix-style line endings (`'\n'`).

If they fail to do so, Bash scripts (such as [./reindex.sh](reindex.sh)] may fail at runtime due to improper interpretation, since Bash only expects Unix-style line endings. This could be problematic for folks wanting to submit PRs for data modifications.

To work around this, I'd like to propose adding and configuring a `.gitattributes` file to ensure Git will always check out Bash scripts with the correct line-ending sequence, regardless of environment.