### PR TITLE
Fixed sorting caused by discrepancies between entity name and id

### DIFF
--- a/bin/util
+++ b/bin/util
@@ -211,7 +211,7 @@ async function indexVillagers(es, newIndexName) {
             suggest: {
                 input: parsed.name
             },
-            keyword: parsed.id,
+            keyword: formatHelper.getSlug(parsed.name),
             gender: parsed.gender,
             species: parsed.species,
             name: parsed.name,
@@ -274,7 +274,7 @@ async function indexItems(es, newIndexName) {
             suggest: {
                 input: parsed.name
             },
-            keyword: parsed.id,
+            keyword: formatHelper.getSlug(parsed.name),
             name: parsed.name,
             ngram: parsed.name,
             category: parsed.category,

--- a/helpers/format.js
+++ b/helpers/format.js
@@ -251,22 +251,22 @@ module.exports.listSortComparator = listSortComparator;
  * @returns {number}
  */
 function listItemSortComparator(a, b) {
-    if (a.id < b.id) {
+    if (a.nameSlug < b.nameSlug) {
         return -1;
-    } else if (a.id > b.id) {
+    } else if (a.nameSlug > b.nameSlug) {
         return 1;
     }
 
     // If we're still here, and there's a variation ID, sort on it.
-    if (a.variationId && b.variationId) {
-        if (a.variationId < b.variationId) {
+    if (a.variationSlug && b.variationSlug) {
+        if (a.variationSlug < b.variationSlug) {
             return -1;
-        } else if (a.variationId > b.variationId) {
+        } else if (a.variationSlug > b.variationSlug) {
             return 1;
         }
-    } else if (!a.variationId && b.variationId) {
+    } else if (!a.variationSlug && b.variationSlug) {
         return -1;
-    } else if (a.variationId && !b.variationId) {
+    } else if (a.variationSlug && !b.variationSlug) {
         return 1;
     }
 }

--- a/routes/user.js
+++ b/routes/user.js
@@ -134,6 +134,7 @@ async function loadList(username, listId, loggedInUser) {
 function organizeData(listId, entity, type, variationId) {
     let entityData = {};
     entityData.name = entity.name;
+    entityData.nameSlug = format.getSlug(entity.name);
     entityData.id = entity.id;
     entityData.type = type;
     entityData.image = entity.image.thumb;
@@ -150,6 +151,7 @@ function organizeData(listId, entity, type, variationId) {
             variationDisplay = entity.variations[variationId];
         }
         entityData.variationId = variationId;
+        entityData.variationSlug = format.getSlug(variationDisplay);
         entityData.variation = '(' + variationDisplay + ')';
         entityData.deleteUrl += '/' + variationId;
         entityData._sortKey += '-vv-' + variationId;


### PR DESCRIPTION
Example: Light Switch was being sorted wrong due to a name change from the 1.2 update. It was sorting by its id (switch), but now it's sorting by the slug of it's name. Also fixed for variations for things like Diner set Sapphire -> Aquamarine. 

Resolves #255 