### PR TITLE
Realtime image resizing

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ const authRouter = require('./routes/auth');
 const userRouter = require('./routes/user');
 const listRouter = require('./routes/list');
 const randomRouter = require('./routes/random');
+const imageResizer = require('./routes/images');
 
 const app = express();
 
@@ -60,6 +61,9 @@ app.use('/auth', authRouter);
 app.use('/list', listRouter);
 app.use('/user', userRouter);
 app.use('/random', randomRouter);
+
+// For image resizing.
+app.use(imageResizer);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/bin/health
+++ b/bin/health
@@ -11,15 +11,15 @@ const urlHelper = require('../helpers/url');
  * @param entityId
  * @param variationId
  */
-function reportOnImage(entityId, variationId) {
+function isImageMissing(entityId, variationId) {
     const missing = [];
 
     const imageData = urlHelper.getEntityImageData(urlHelper.ITEM, entityId, variationId, false);
-    if (!imageData.full) {
-        missing.push('full');
+    if (!imageData) {
+        return true;
     }
 
-    return missing;
+    return false;
 }
 
 /**
@@ -33,10 +33,11 @@ function itemHealthReport() {
         const games = Object.keys(parsed.games).join('; ');
 
         // Check base image.
-        const baseOutput = reportOnImage(parsed.id);
+        const baseImageMissing = isImageMissing(parsed.id);
         let basePrinted = false;
-        if (baseOutput.length > 0) {
-            console.log(parsed.id + ' (games: ' + games + '): Missing ' + baseOutput.join(', '));
+        if (baseImageMissing) {
+            console.log(parsed.id + ' (games: ' + games + '):');
+            console.log('\tMissing base image');
             basePrinted = true;
         }
         // Check variants - NH only - and only if more than one
@@ -44,18 +45,17 @@ function itemHealthReport() {
             const variationList = Object.keys(parsed.games.nh.variations);
             if (variationList.length > 1) {
                 for (let variationId of variationList) {
-                    const variationOutput = reportOnImage(parsed.id, variationId);
-                    if (variationOutput.length > 0) {
+                    const variationImageMissing = isImageMissing(parsed.id, variationId);
+                    if (variationImageMissing) {
                         if (!basePrinted) {
                             console.log(parsed.id + ' (games: ' + games + '):');
                             basePrinted = true;
                         }
-                        console.log('\t' + variationId + ': Missing ' + variationOutput.join(', '));
+                        console.log('\t' + variationId + ': Missing variation image');
                     }
                 }
             }
         }
-
     }
 }
 

--- a/bin/health
+++ b/bin/health
@@ -18,12 +18,6 @@ function reportOnImage(entityId, variationId) {
     if (!imageData.full) {
         missing.push('full');
     }
-    if (!imageData.medium) {
-        missing.push('medium');
-    }
-    if (!imageData.thumb) {
-        missing.push('thumb');
-    }
 
     return missing;
 }

--- a/bin/health
+++ b/bin/health
@@ -12,8 +12,6 @@ const urlHelper = require('../helpers/url');
  * @param variationId
  */
 function isImageMissing(entityId, variationId) {
-    const missing = [];
-
     const imageData = urlHelper.getEntityImageData(urlHelper.ITEM, entityId, variationId, false);
     if (!imageData) {
         return true;

--- a/db/entity/items.js
+++ b/db/entity/items.js
@@ -288,14 +288,12 @@ class Items extends RedisStore {
         for (let k of keys) {
             let imageData = urlHelper.getEntityImageData(this.entityType, item.id, k, false);
             // use base images if no variation image available.
-            if (!imageData.thumb) {
-                imageData.thumb = item.image.thumb;
-            }
-            if (!imageData.medium) {
-                imageData.medium = item.image.medium;
-            }
-            if (!imageData.full) {
-                imageData.full = item.image.full;
+            if (!imageData) {
+                imageData = {
+                    thumb: item.image.thumb,
+                    medium: item.image.medium,
+                    full: item.image.full
+                }
             }
             item.variationImages[k] = imageData;
         }

--- a/helpers/url.js
+++ b/helpers/url.js
@@ -171,7 +171,7 @@ module.exports.getImageUrl = getImageUrl;
  * @param variationId if defined, refer to the variation image
  * @param usePlaceholderImage if true (default), returns a placeholder image instead of undefined if image does not
  * exist on disk.
- * @returns {{thumb: *, medium: *, full: *}}
+ * @returns {{thumb: *, medium: *, full: *}|undefined}
  */
 module.exports.getEntityImageData = (entityType, id, variationId = undefined,
                                      usePlaceholderImage = true) => {
@@ -179,11 +179,15 @@ module.exports.getEntityImageData = (entityType, id, variationId = undefined,
     const url = getImageUrl(entityType, FULL, id, variationId);
     if (!url) {
         // Return image not found images if we're supposed to.
-        return {
-            thumb: usePlaceholderImage ? getImageNotFoundFilename(THUMB) : undefined,
-            medium: usePlaceholderImage ? getImageNotFoundFilename(MEDIUM) : undefined,
-            full: usePlaceholderImage ? getImageNotFoundFilename(FULL) : undefined
-        };
+        if (usePlaceholderImage) {
+            return {
+                thumb:  getImageNotFoundFilename(THUMB),
+                medium: getImageNotFoundFilename(MEDIUM),
+                full:  getImageNotFoundFilename(FULL)
+            };
+        } else {
+            return;
+        }
     }
 
     // Otherwise, get the hash and compute some URLs.
@@ -215,7 +219,7 @@ module.exports.getEntityUrl = (entityType, id) => {
  */
 const computeStaticAssetUrl = (inputUrl, computedHash) => {
     if (typeof inputUrl !== 'string') {
-        return undefined;
+        return;
     }
 
     const hash = computedHash ? computedHash : createFileHash(path.join(process.cwd(), 'public', inputUrl));

--- a/helpers/url.js
+++ b/helpers/url.js
@@ -143,8 +143,7 @@ module.exports.VILLAGER = VILLAGER;
  * @param variationId if defined, refer to the variation image
  * @returns {string}
  */
-const getImageUrl = (entityType, imageType, id, variationId = undefined,
-                     usePlaceholderImage = true) => {
+const getImageUrl = (entityType, imageType, id, variationId = undefined) => {
     if (imageType == THUMB || imageType == MEDIUM || imageType == FULL) {
         let imageId = id;
         if (variationId) {

--- a/helpers/url.js
+++ b/helpers/url.js
@@ -62,12 +62,28 @@ const staticCache = {};
 /**
  * The path for an image that can't be found.
  *
- * @param type THUMB, MEDIUM or FULL.
+ * @param size THUMB, MEDIUM or FULL.
  * @returns {string}
  */
-function getImageNotFoundFilename(type) {
-    return '/images/image-not-available-' + type + '.svg';
+function getImageNotFoundFilename(size) {
+    return '/images/image-not-available-' + size + '.svg';
 }
+
+/**
+ * Create the URL suffix hash for a file.
+ * @param filePath path to the file to hash
+ *
+ * @returns {string|undefined}
+ */
+function createFileHash(filePath) {
+    if (fs.existsSync(filePath)) {
+        const fileStr = fs.readFileSync(filePath, 'utf8');
+        return crypto.createHash('md5')
+            .update(fileStr, 'utf8')
+            .digest('hex')
+            .substr(0, HASH_LENGTH);
+    }
+};
 
 /**
  * Insert hash string into the last segment of URL before file extension.
@@ -125,8 +141,6 @@ module.exports.VILLAGER = VILLAGER;
  * @param imageType: one of THUMB, MEDIUM or FULL.
  * @param id
  * @param variationId if defined, refer to the variation image
- * @param usePlaceholderImage if true (default), returns a placeholder image instead of undefined if image does not
- * exist on disk.
  * @returns {string}
  */
 const getImageUrl = (entityType, imageType, id, variationId = undefined,
@@ -136,7 +150,9 @@ const getImageUrl = (entityType, imageType, id, variationId = undefined,
         if (variationId) {
             imageId += '-vv-' + variationId;
         }
-        const pathPrefix = './public/images/' + entityType + 's/' + imageType + '/' + imageId;
+
+        // Always use full image for checking existence - other types are generated
+        const pathPrefix = './public/images/' + entityType + 's/' + FULL + '/' + imageId;
         if (fs.existsSync(pathPrefix + '.png')) {
             return '/images/' + entityType + 's/' + imageType + '/' + imageId + '.png';
         } else if (fs.existsSync(pathPrefix + '.jpg')) {
@@ -144,11 +160,6 @@ const getImageUrl = (entityType, imageType, id, variationId = undefined,
         } else if (fs.existsSync(pathPrefix + '.jpeg')) {
             return '/images/' + entityType + 's/' + imageType + '/' + imageId + '.jpeg';
         }
-    }
-
-    // Image not found.
-    if (usePlaceholderImage) {
-        return getImageNotFoundFilename(imageType);
     }
 }
 module.exports.getImageUrl = getImageUrl;
@@ -165,10 +176,23 @@ module.exports.getImageUrl = getImageUrl;
  */
 module.exports.getEntityImageData = (entityType, id, variationId = undefined,
                                      usePlaceholderImage = true) => {
+    // Get the full size image URL... does the image exist?
+    const url = getImageUrl(entityType, FULL, id, variationId);
+    if (!url) {
+        // Return image not found images if we're supposed to.
+        return {
+            thumb: usePlaceholderImage ? getImageNotFoundFilename(THUMB) : undefined,
+            medium: usePlaceholderImage ? getImageNotFoundFilename(MEDIUM) : undefined,
+            full: usePlaceholderImage ? getImageNotFoundFilename(FULL) : undefined
+        };
+    }
+
+    // Otherwise, get the hash and compute some URLs.
+    const hash = createFileHash(path.join(process.cwd(), 'public', url));
     return {
-        thumb: computeStaticAssetUrl(getImageUrl(entityType, THUMB, id, variationId, usePlaceholderImage)),
-        medium: computeStaticAssetUrl(getImageUrl(entityType, MEDIUM, id, variationId, usePlaceholderImage)),
-        full: computeStaticAssetUrl(getImageUrl(entityType, FULL, id, variationId, usePlaceholderImage))
+        thumb: computeStaticAssetUrl(getImageUrl(entityType, THUMB, id, variationId), hash),
+        medium: computeStaticAssetUrl(getImageUrl(entityType, MEDIUM, id, variationId), hash),
+        full: computeStaticAssetUrl(getImageUrl(entityType, FULL, id, variationId), hash)
     };
 };
 
@@ -185,24 +209,21 @@ module.exports.getEntityUrl = (entityType, id) => {
 
 /**
  * Compute a static asset URL suitable for CDN use. Computations are not cached.
+ *
  * @param inputUrl
- * @returns {string}
+ * @param computedHash optional hash to add - if not set, will be computed
+ * @returns {string|undefined}
  */
-const computeStaticAssetUrl = (inputUrl) => {
+const computeStaticAssetUrl = (inputUrl, computedHash) => {
     if (typeof inputUrl !== 'string') {
-        return;
+        return undefined;
     }
 
-    const filePath = path.join(process.cwd(), 'public', inputUrl);
-    if (fs.existsSync(filePath)) {
-        const fileStr = fs.readFileSync(filePath, 'utf8');
-        const hash = crypto.createHash('md5')
-            .update(fileStr, 'utf8')
-            .digest('hex')
-            .substr(0, HASH_LENGTH);
+    const hash = computedHash ? computedHash : createFileHash(path.join(process.cwd(), 'public', inputUrl));
+    if (hash) {
         return addHashToUrl(inputUrl, hash);
     } else {
-        // No such file. Just return as is.
+        // Hashing failed. Return as-is.
         return inputUrl;
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,6 +2024,15 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2295,6 +2304,42 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "bluebird": {
       "version": "3.7.1",
@@ -2750,6 +2795,11 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "coffeescript": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
@@ -2765,6 +2815,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2777,6 +2836,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "colors": {
       "version": "1.1.2",
@@ -2864,6 +2932,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3101,11 +3174,18 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -3158,6 +3238,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "optional": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -3181,6 +3266,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3503,6 +3593,11 @@
           }
         }
       }
+    },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "expand-tilde": {
       "version": "2.0.2",
@@ -3897,6 +3992,11 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -4400,6 +4500,54 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
@@ -4447,6 +4595,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
       "version": "7.1.5",
@@ -4897,6 +5050,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -5833,6 +5991,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5907,6 +6070,11 @@
         }
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -5977,6 +6145,11 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -5991,6 +6164,19 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-abi": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node-addon-api": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
+      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
     },
     "node-cron": {
       "version": "2.0.3",
@@ -6189,6 +6375,11 @@
         }
       }
     },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -6222,6 +6413,22 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth": {
       "version": "0.9.15",
@@ -6680,6 +6887,45 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
+    "prebuild-install": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
+      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "simple-get": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "requires": {
+            "decompress-response": "^4.2.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        }
+      }
+    },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -6862,7 +7108,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6873,8 +7118,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -7406,6 +7650,29 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "sharp": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.1.tgz",
+      "integrity": "sha512-9MhwS4ys8pnwBH7MtnBdLzUv+cb24QC4xbzzQL6A+1MQ4Se2V6oPHEX8TIGIZUPRKi6S1kJPVNzt/Xqqp6/H3Q==",
+      "requires": {
+        "color": "^3.1.2",
+        "detect-libc": "^1.0.3",
+        "node-addon-api": "^3.0.2",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.3.5",
+        "semver": "^7.3.2",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.1.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7423,6 +7690,51 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
     },
     "slick-carousel": {
       "version": "1.8.1",
@@ -7764,8 +8076,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "6.1.0",
@@ -7779,6 +8090,41 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+    },
+    "tar-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "term-size": {
       "version": "1.2.0",
@@ -8014,7 +8360,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -8480,6 +8825,43 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "widest-line": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3642,6 +3642,28 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "send": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          }
+        }
       }
     },
     "express-handlebars": {
@@ -7570,9 +7592,9 @@
       }
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -7581,12 +7603,51 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "serialize-javascript": {
@@ -7603,6 +7664,28 @@
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.2",
         "send": "0.16.2"
+      },
+      "dependencies": {
+        "send": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          }
+        }
       }
     },
     "set-blocking": {
@@ -8312,6 +8395,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "touch": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "redis": "^2.8.0",
+    "sharp": "^0.26.1",
     "slick-carousel": "^1.8.1",
     "underscore": "^1.9.1",
     "webpack": "^4.41.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "redis": "^2.8.0",
+    "send": "^0.17.1",
     "sharp": "^0.26.1",
     "slick-carousel": "^1.8.1",
     "underscore": "^1.9.1",

--- a/routes/images.js
+++ b/routes/images.js
@@ -46,13 +46,13 @@ module.exports = (req, res, next) => {
 
         // Is it a valid entity type?
         if (!RESIZE_RULES[entityType] || !RESIZE_RULES[entityType][size]) {
-            next(); // bail
+            return next(); // bail
         }
 
         // Does the referenced file exist as a full image?
         const originalFile = path.join(process.cwd(), 'public', 'images', entityType, 'full', file);
         if (!fs.existsSync(originalFile)) {
-            next(); // bail
+            return next(); // bail
         }
 
         // Build the new file
@@ -75,7 +75,7 @@ module.exports = (req, res, next) => {
         // Save to disk.
         resharp.toFile(newFile, (err, info) => {
             if (err) {
-                next(err); // bail!
+                return next(err); // bail!
             }
 
             // Send the new file with max age 1 year
@@ -83,6 +83,6 @@ module.exports = (req, res, next) => {
                 .pipe(res);
         });
     } else {
-        next(); // not found
+        return next(); // not found
     }
 };

--- a/routes/images.js
+++ b/routes/images.js
@@ -1,0 +1,13 @@
+module.exports = (req, res, next) => {
+    const match = req.url.match(/^\/images\/([a-zA-z0-9]+)\/(medium|thumb)\/(.+)/);
+    if (match) {
+        const entityType = match[1];
+        const size = match[2];
+        const file = match[3];
+        console.log(entityType + ' ' + size + ' ' + file + ' ');
+        next(); // TODO remove
+    } else {
+        next();
+    }
+
+};

--- a/routes/images.js
+++ b/routes/images.js
@@ -50,13 +50,13 @@ module.exports = (req, res, next) => {
         }
 
         // Does the referenced file exist as a full image?
-        const originalFile = path.join('public', 'images', entityType, 'full', file);
+        const originalFile = path.join(process.cwd(), 'public', 'images', entityType, 'full', file);
         if (!fs.existsSync(originalFile)) {
             next(); // bail
         }
 
         // Build the new file
-        const newFile = path.join('public', 'images', entityType, size, file);
+        const newFile = path.join(process.cwd(), 'public', 'images', entityType, size, file);
         sharp(originalFile)
             .resize(RESIZE_RULES[entityType][size].width, RESIZE_RULES[entityType][size].height,
                 {

--- a/routes/images.js
+++ b/routes/images.js
@@ -1,13 +1,78 @@
+const path = require('path');
+const fs = require('fs');
+const sharp = require('sharp');
+const send = require('send');
+
+/**
+ * Resizing rules based on entity type and requested size.
+ */
+const RESIZE_RULES = {
+    items: {
+        thumb: {
+            width: 100,
+            height: 100
+        },
+        medium: {
+            width: 200,
+            height: 200
+        }
+    },
+    villagers: {
+        thumb: {
+            width: 100,
+            height: 100
+        },
+        medium: {
+            width: 200,
+            height: 200
+        }
+    }
+};
+
+/**
+ * HTTP header options for send module.
+ */
+const SEND_OPTIONS = {
+    maxAge: process.env.NODE_ENV === 'production' ? '1y' : 0 // 1 year cache in prod
+};
+
 module.exports = (req, res, next) => {
+    // Does it match an image url?
     const match = req.url.match(/^\/images\/([a-zA-z0-9]+)\/(medium|thumb)\/(.+)/);
     if (match) {
         const entityType = match[1];
         const size = match[2];
         const file = match[3];
-        console.log(entityType + ' ' + size + ' ' + file + ' ');
-        next(); // TODO remove
-    } else {
-        next();
-    }
 
+        // Is it a valid entity type?
+        if (!RESIZE_RULES[entityType] || !RESIZE_RULES[entityType][size]) {
+            next(); // bail
+        }
+
+        // Does the referenced file exist as a full image?
+        const originalFile = path.join('public', 'images', entityType, 'full', file);
+        if (!fs.existsSync(originalFile)) {
+            next(); // bail
+        }
+
+        // Build the new file
+        const newFile = path.join('public', 'images', entityType, size, file);
+        sharp(originalFile)
+            .resize(RESIZE_RULES[entityType][size].width, RESIZE_RULES[entityType][size].height,
+                {
+                    fit: 'inside',
+                    withoutEnlargement: true
+                })
+            .toFile(newFile, (err, info) => {
+                if (err) {
+                    next(err); // bail!
+                }
+
+                // Send the new file with max age 1 year
+                send(req, newFile, SEND_OPTIONS)
+                    .pipe(res);
+            });
+    } else {
+        next(); // not found
+    }
 };

--- a/routes/images.js
+++ b/routes/images.js
@@ -80,6 +80,9 @@ module.exports = (req, res, next) => {
 
             // Send the new file with max age 1 year
             send(req, newFile, SEND_OPTIONS)
+                .on('error', (err) => {
+                    return next(err);
+                })
                 .pipe(res);
         });
     } else {


### PR DESCRIPTION
So we can stop managing these all the time and going crazy.

Indexers have been refactored where appropriate. The most fundamental change is that the cache-busting hash is now computed from the full-size image only. We cannot compute hash addresses in advance for the medium and thumb size images anymore because they are not known at index time. 