### PR TITLE
Migrate CatalogScanner to new nook.lol domain

### DIFF
--- a/routes/list.js
+++ b/routes/list.js
@@ -101,10 +101,10 @@ async function listImport(req, listName, listId) {
     // Set timeout and make request
     const https = axios.create();
     https.defaults.timeout = 10000; // TODO maybe move to env?
-    https.defaults.timeoutErrorMessage = "ehsan.lol took too long to respond...";
+    https.defaults.timeoutErrorMessage = "nook.lol took too long to respond...";
 
     // use `/raw` endpoint to avoid getting HTML, and `locale=en-us` to translate the response.
-    const requestUrl = 'https://ehsan.lol/' + listId + '/raw?locale=en-us';
+    const requestUrl = 'https://nook.lol/' + listId + '/raw?locale=en-us';
     const urlResponse = await https.get(requestUrl);
 
     // Split up the reply and
@@ -236,9 +236,9 @@ router.post('/import',
     listValidation.concat([
         body(
             'list-url',
-            'Please make sure your URL is of the form ehsan.lol/abc, http://ehsan.lol/xyz, or http://ehsan.lol/jkl.')
+            'Please make sure your URL is of the form nook.lol/abc, http://nook.lol/xyz, or https://nook.lol/jkl.')
             .trim()
-            .matches(/^((http(s?))\:\/\/)?(ehsan\.lol\/)([A-za-z0-9]+)$/)
+            .matches(/^((http(s?))\:\/\/)?((ehsan|nook)\.lol\/)([A-za-z0-9]+)$/)
     ]),
     (req, res, next) => {
     // Only registered users here.

--- a/views/import-list.hbs
+++ b/views/import-list.hbs
@@ -1,5 +1,5 @@
 <h1>Import with CatalogScanner</h1>
-<p>You can import a list using <a target="_blank" href="https://ehsan.lol">CatalogScanner</a>.
+<p>You can import a list using <a target="_blank" href="https://nook.lol">CatalogScanner</a>.
 Follow the instructions and paste the link in here to import your catalog quickly and easily.</p>
 {{#each errors}}
     <div class="alert alert-danger">
@@ -16,8 +16,8 @@ Follow the instructions and paste the link in here to import your catalog quickl
         </small>
         <label for="list-url">Import URL</label>
         <input type="text" name="list-url" class="form-control" id="list-url"
-               aria-describedby="list-url-help" placeholder="https://ehsan.lol/wxyz"
-               {{#if predefinedUrl}}value="ehsan.lol/{{predefinedUrl}}"{{/if}}>
+               aria-describedby="list-url-help" placeholder="https://nook.lol/xyz"
+               {{#if predefinedUrl}}value="nook.lol/{{predefinedUrl}}"{{/if}}>
         <small id="list-url-help" class="form-text text-muted">
             Enter the URL the CatalogScanner app gave you on Twitter
         </small>


### PR DESCRIPTION
I'm trying to transfer CatalogScanner to a new domain, though the old one will stay up and available during migration and probably for the forseeable future. The new regex handles both, but the branding should refer to the new domain.