### PR TITLE
Small fix for autocomplete issues on Firefox browser

### DIFF
--- a/views/list/view.hbs
+++ b/views/list/view.hbs
@@ -77,7 +77,7 @@
                     {{/if}}
                 </div>
                 {{#if ../isOwnUser}}
-                    <form class="list-item-updater mt-2" data-update-url="{{updateUrl}}">
+                    <form class="list-item-updater mt-2" data-update-url="{{updateUrl}}" autocomplete="off">
                         <div class="form-group mb-0">
                             <input type="text" class="form-control list-item-updater-text" placeholder="Enter something (LF, FT, need 100, etc.)"
                                    {{#if text}}value="{{text}}"{{/if}} maxlength="255">


### PR DESCRIPTION
To test:
0. On Firefox:
1. Enter a comment on an entity in a list and save it
2. Delete that entity
3. Refresh the page
4. Show Text and notice the comment from the deleted entity appears on the entity that took its position in the list