### PR TITLE
Adding clear button for search bar

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -122,3 +122,14 @@ a.no-link-underline:hover {
     padding-bottom: 60px;
   }
 }
+
+.clear-search-btn {
+  z-index: 100;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-left: none;
+
+  span {
+    color: #343a40;
+  }
+}

--- a/views/partials/search-bar.hbs
+++ b/views/partials/search-bar.hbs
@@ -5,6 +5,9 @@
             <input type="hidden" name="game" value="nh"/>
             <input type="text" class="form-control" maxlength="64" id="q" name="q"
                    placeholder="Item or villager name" autoComplete="off" value="{{searchQuery}}"/>
+            <button type="reset" class="clear-search-btn btn">
+                <span class="fa fa-times"></span>
+            </button>
             <ul id="autocomplete-items" style="display: none;"></ul>
             <span class="input-group-btn">
                 <button class="btn btn-primary" type="submit"><span class="fas fa-search"></span></button>


### PR DESCRIPTION
Small change to allow users to clear their search bar. Especially beneficial to mobile users who wish to remove a search without tap and hold or backspacing. 