### PR TITLE
UI: Set explicit width and height on list view images

### DIFF
--- a/public/stylesheets/users.less
+++ b/public/stylesheets/users.less
@@ -53,3 +53,19 @@
     display: block;
   }
 }
+
+.user-list-thumb {
+  width: 50px;
+  height: 50px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+}
+
+.user-list-image {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/views/list/compare.hbs
+++ b/views/list/compare.hbs
@@ -46,12 +46,11 @@
             <li class="list-compare-{{compareStatus}} list-group-item d-flex justify-content-between align-items-center" data-name="{{name}} {{variation}}">
                 <div>
                     <a href="/{{type}}/{{id}}" class="no-link-underline">
-                        <img src="{{image}}"
-                             alt="Picture of {{name}}"
-                             class="img-responsive"
-                             width="50"
-                             height="50"
-                             style="max-width: 50px;" />
+                        <div class="user-list-thumb">
+                            <img src="{{image}}"
+                                 alt="Picture of {{name}}"
+                                 class="img-responsive user-list-image" />
+                        </div>
                     </a>
                     {{#if isDIY}}
                         <img src="/images/diy.1111111.png" alt="DIY Icon"/>

--- a/views/list/compare.hbs
+++ b/views/list/compare.hbs
@@ -46,8 +46,12 @@
             <li class="list-compare-{{compareStatus}} list-group-item d-flex justify-content-between align-items-center" data-name="{{name}} {{variation}}">
                 <div>
                     <a href="/{{type}}/{{id}}" class="no-link-underline">
-                        <img src="{{image}}" alt="Picture of {{name}}"
-                             class="img-responsive" style="max-width: 50px;">
+                        <img src="{{image}}"
+                             alt="Picture of {{name}}"
+                             class="img-responsive"
+                             width="50"
+                             height="50"
+                             style="max-width: 50px;" />
                     </a>
                     {{#if isDIY}}
                         <img src="/images/diy.1111111.png" alt="DIY Icon"/>

--- a/views/list/view.hbs
+++ b/views/list/view.hbs
@@ -69,12 +69,11 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
                         <a href="/{{type}}/{{id}}" class="no-link-underline">
-                            <img src="{{image}}"
-                                 alt="Picture of {{name}}"
-                                 class="img-responsive user-list-image"
-                                 width="50"
-                                 height="50"
-                                 style="max-width: 50px;" />
+                            <div class="user-list-thumb">
+                                <img src="{{image}}"
+                                     alt="Picture of {{name}}"
+                                     class="img-responsive user-list-image" />
+                            </div>
                         </a>
                         {{#if isDIY}}
                             <img src="/images/diy.1111111.png" alt="DIY Icon"/>

--- a/views/list/view.hbs
+++ b/views/list/view.hbs
@@ -69,8 +69,12 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
                         <a href="/{{type}}/{{id}}" class="no-link-underline">
-                            <img src="{{image}}" alt="Picture of {{name}}"
-                                 class="img-responsive user-list-image" style="max-width: 50px;">
+                            <img src="{{image}}"
+                                 alt="Picture of {{name}}"
+                                 class="img-responsive user-list-image"
+                                 width="50"
+                                 height="50"
+                                 style="max-width: 50px;" />
                         </a>
                         {{#if isDIY}}
                             <img src="/images/diy.1111111.png" alt="DIY Icon"/>


### PR DESCRIPTION
Setting an explicit width and height on these images will reduce the amount of layout shifting that occurs during page load.