### PR TITLE
Data Entry: Correct categories for Baabara's Poster and Nook Inc. Poster

### DIFF
--- a/data/items/baabaras-poster.json
+++ b/data/items/baabaras-poster.json
@@ -3,6 +3,9 @@
   "name": "Baabara's Poster",
   "games": {
     "nh": {
+      "sources": [
+        "Nook Shopping after using Amiibo on Harvey's Island"
+      ],
       "sellPrice": {
         "currency": "bells",
         "value": 250
@@ -15,5 +18,5 @@
       ]
     }
   },
-  "category": "Furniture"
+  "category": "Photos"
 }

--- a/data/items/nook-inc-poster.json
+++ b/data/items/nook-inc-poster.json
@@ -15,5 +15,5 @@
       ]
     }
   },
-  "category": "Photos"
+  "category": "Furniture"
 }


### PR DESCRIPTION
Baabara's Poster should be moved from "Furniture" to "Photos".
https://villagerdb.com/item/baabaras-poster

Nook Inc. Poster should be moved from "Photos" to "Furniture".
https://villagerdb.com/item/nook-inc-poster
